### PR TITLE
Move to egi-foundation roles

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -1,4 +1,5 @@
 ---
 - hosts: all
   roles:
-  - caso
+  - { role: EGI-Foundation.cmd }
+  - { role: EGI-Foundation.caso }

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,2 @@
-- src: https://github.com/egi-qc/ansible-cmd
-  version: master
-  name: umd
+- src: EGI-Foundation.cmd
+- src: EGI-Foundation.caso


### PR DESCRIPTION
Try to move this to the EGI-Foundation roles now available in Galaxy.

Example vars:
```
---
# not applicable
#distribution: cmd
cmd_distribution: cmd-os
cmd_release: 1


#enable_testing_repo: false


cmd_enable_candidate_repo: false

cmd_openstack_release: mitaka
# not sure of what this does, but not used in the role now
#igtf_repo: False

verification_repofile:
  - http://admin-repo.egi.eu/sw/unverified/cmd-os-0.ifca.caso.centos7.x86_64/1/1/0/repofiles/IFCA.caso.centos7.x86_64.repo

caso_site_name: UMD
caso_extractor: nova
caso_auth:
  auth_type: password
  auth_url: http://172.16.39.7/identity
  username: admin
  user_domain_name: default
  password: secret
caso_output_path: /var/spool/apel/outgoing/openstack

caso_vos:
  demo:
  - demo
```